### PR TITLE
Fixed backslash in string litteral breaking syntax highlighting

### DIFF
--- a/src/ddc/lexer/tokenizer.d
+++ b/src/ddc/lexer/tokenizer.d
@@ -2605,10 +2605,12 @@ class Tokenizer
                     else
                         lastBackSlash = true;
                 }
-				if (ch == delimiter && !lastBackSlash) {
+                else if (ch == delimiter && !lastBackSlash) {
 					endPos = i;
 					break;
 				}
+                else if(lastBackSlash)
+                    lastBackSlash = false;
 			}
 			if (endPos != int.max) {
 				// found end quote


### PR DESCRIPTION
Fixes #40 

If we recorded a backslash and the current character is not a delminator or backslash, the previous backslash did not terminate the string.

Tested against Issue #38, which remains fixed with my changes.