### PR TITLE
dlang ide crashed on opening an workspace by selecting an dub file.

### DIFF
--- a/src/dlangide/workspace/workspace.d
+++ b/src/dlangide/workspace/workspace.d
@@ -58,7 +58,7 @@ class Workspace : WorkspaceItem {
     protected BuildConfiguration _buildConfiguration;
     protected ProjectConfiguration _projectConfiguration = ProjectConfiguration.DEFAULT;
     
-    this(IDEFrame frame, string fname = null) {
+    this(IDEFrame frame, string fname = WORKSPACE_EXTENSION) {
         super(fname);
         _workspaceFile = new SettingsFile(fname);
         _settings = new WorkspaceSettings(fname ? fname ~ WORKSPACE_SETTINGS_EXTENSION : null);


### PR DESCRIPTION
E.g. when i tied to open the dlangide directory itself.

The stacktrace shows that it tried to save some settings but the file name was null. So I changed the default settings file name in worspace.d file from null to
WORKSPACE_EXTENSION. This way i was able to open the the workspace. I am new to d and to this project so I might not get the hole picture here and doing something wrong, please double check if that's the correct way to fix that.