### PR TITLE
configure gdb to ignore garbage collection signals

### DIFF
--- a/src/ddebug/gdb/gdbinterface.d
+++ b/src/ddebug/gdb/gdbinterface.d
@@ -271,6 +271,8 @@ class GDBInterface : ConsoleDebuggerInterface, TextCommandTarget {
     /// start program execution, can be called after program is loaded
     int _startRequestId;
     void execStart() {
+        sendCommand("handle SIGUSR1 nostop noprint");
+        sendCommand("handle SIGUSR2 nostop noprint");
         _startRequestId = sendCommand("-exec-run");
     }
 


### PR DESCRIPTION
to do so i send following commands following to gdb on startup:
handle SIGUSR1 nostop noprint
handle SIGUSR2 nostop noprint

this prevents gdp from beeing interuppted by garbage collection signals