### PR TITLE
fix range violation on deleting breakpoints

### DIFF
--- a/src/ddebug/gdb/gdbinterface.d
+++ b/src/ddebug/gdb/gdbinterface.d
@@ -383,10 +383,10 @@ class GDBInterface : ConsoleDebuggerInterface, TextCommandTarget {
             if (!found) {
                 for (int j = i; j < _breakpoints.length - 1; j++)
                     _breakpoints[j] = _breakpoints[j + 1];
-                _breakpoints.length = _breakpoints.length - 1;
                 if (breakpointsToDelete.length)
                     breakpointsToDelete ~= ",";
                 breakpointsToDelete ~= _breakpoints[i].number;
+                _breakpoints.length = _breakpoints.length - 1;
             }
         }
         // checking for added or updated breakpoints


### PR DESCRIPTION
#97 change the length of the array after accessing that array

please double check it is just a guess, that this fixes that range  violation