### PR TITLE
Offer creation of missing target location

### DIFF
--- a/src/dlangide/ui/newproject.d
+++ b/src/dlangide/ui/newproject.d
@@ -270,6 +270,22 @@ class NewProjectDlg : Dialog {
     override void close(const Action action) {
         Action newaction = action.clone();
         if (action.id == IDEActions.FileNewWorkspace || action.id == IDEActions.FileNewProject) {
+            if (!exists(_location)) {
+                // show message box with OK and CANCEL buttons, cancel by default, and handle its result
+                window.showMessageBox(UIString("Cannot create project"d), UIString("The target location does not exist.\nDo you want to create the target directory?"), [ACTION_YES, ACTION_CANCEL], 1, delegate(const Action a) {
+                    if (a.id == StandardAction.Yes) {
+                        try {
+                            mkdirRecurse(_location);
+                            close(action);
+                        } catch (Exception e) {
+                            setError("Cannot create target location");
+                            window.showMessageBox(UIString("Cannot create project"d), UIString(getError()));
+                        }
+                    }
+                    return true;
+                });
+                return;
+            }
             if (!validate()) {
                 window.showMessageBox(UIString("Cannot create project"d), UIString(getError()));
                 return;


### PR DESCRIPTION
If you create a new workspace or project and enter a non-existing path
the IDE just complained that the path did not exist, forcing you to go
out of your way and manually set one up. It now offers you to create
the missing directories for you.

~~Depends on buggins/dlangui#147~~
Changed to use builtin phobos method.