### PR TITLE
Create source directory for empty projects

### DIFF
--- a/src/dlangide/ui/newproject.d
+++ b/src/dlangide/ui/newproject.d
@@ -355,10 +355,10 @@ class NewProjectDlg : Dialog {
         ws.addProject(project);
         if (ws.startupProject is null)
             ws.startupProject = project;
+        string srcdir = buildNormalizedPath(pdir, "source");
+        if (!exists(srcdir))
+            mkdir(srcdir);
         if (!_currentTemplate.srcfile.empty && !_currentTemplate.srccode.empty) {
-            string srcdir = buildNormalizedPath(pdir, "source");
-            if (!exists(srcdir))
-                mkdir(srcdir);
             string srcfile = buildNormalizedPath(srcdir, _currentTemplate.srcfile);
             write(srcfile, _currentTemplate.srccode);
         }


### PR DESCRIPTION
Since the preview shows the creation of a source directory and since
there currently is no functionality to add new source paths to a
project, empty projects were effectively unusable after creation
unless you manually created files/directories for them outside
DlangIDE.

If this behaviour isn't wanted we should add an option to add new source paths to a project in the workspace explorer and fix the previews in the creation dialog.