### PR TITLE
Fix saving/loading startup project of workspace

### DIFF
--- a/src/dlangide/workspace/workspace.d
+++ b/src/dlangide/workspace/workspace.d
@@ -277,6 +277,7 @@ class Workspace : WorkspaceItem {
             Log.e("empty workspace name");
             return false;
         }
+        auto originalStartupProjectName = _settings.startupProjectName;
         Setting projects = _workspaceFile.objectByPath("projects", true);
         foreach(string key, Setting value; projects) {
             string path = value.str;
@@ -287,6 +288,7 @@ class Workspace : WorkspaceItem {
             _projects ~= project;
             project.load();
         }
+        _settings.startupProjectName = originalStartupProjectName;
         fillStartupProject();
         return true;
     }

--- a/src/dlangide/workspace/workspacesettings.d
+++ b/src/dlangide/workspace/workspacesettings.d
@@ -22,8 +22,9 @@ class WorkspaceSettings : SettingsFile {
         return _startupProjectName;
     }
     @property void startupProjectName(string s) {
-        if (s.equal(_startupProjectName)) {
+        if (!s.equal(_startupProjectName)) {
             _startupProjectName = s;
+            _setting["startupProject"] = s;
             save();
         }
     }


### PR DESCRIPTION
If you changed the startup project of a workspace the information wouldn't be written to the workspace settings file and even if you manually edited the workspace settings file the startup project would be overridden because automatically added dependency projects call fillStartupProject() before all projects are loaded, causing the startup project to be erroneously set to the default (first project in workspace).

The former has been taken care of by explicitly setting the startupProject value that is read during load and the latter has been taken care of by caching the original startup project name and reusing it later.