### PR TITLE
rewrite rdmd execution

### DIFF
--- a/src/ddebug/common/nodebug.d
+++ b/src/ddebug/common/nodebug.d
@@ -82,7 +82,7 @@ exit_code=$?
 echo "
 -----------------------
 (program returned exit code: $exit_code)"
-echo "Press any key to continue..."
+echo "Press return to continue..."
 dummy_var=""
 read dummy_var
 exit $exit_code

--- a/src/ddebug/common/nodebug.d
+++ b/src/ddebug/common/nodebug.d
@@ -75,10 +75,22 @@ class ProgramExecutionNoDebug : Thread, ProgramExecution {
         // external console support
         if (!_terminalExecutable.empty) {
             string cmdline = escapeShellCommand(params);
-            params.length = 0;
-            params ~= _terminalExecutable;
-            params ~= "-e";
-            params ~= cmdline;
+            string shellScript = `
+rm $0
+` ~ cmdline ~ `
+exit_code=$?
+echo "
+-----------------------
+(program returned exit code: $exit_code)"
+echo "Press any key to continue..."
+dummy_var=""
+read dummy_var
+exit $exit_code
+`;
+            std.file.write(std.path.buildPath(_executableWorkingDir, "dlangide_run_script.sh"), shellScript);
+            string setExecFlagCommand = escapeShellCommand("chmod", "+x", "dlangide_run_script.sh");
+            spawnShell(setExecFlagCommand, stdin, stdout, stderr, null, Config.none, _executableWorkingDir);
+            params = [_terminalExecutable, "-e", "./dlangide_run_script.sh"];
         }
 
         File newstdin;

--- a/src/dlangide/workspace/workspace.d
+++ b/src/dlangide/workspace/workspace.d
@@ -19,8 +19,7 @@ enum BuildOperation {
     Clean,
     Rebuild,
     Run,
-    Upgrade,
-    RunWithRdmd
+    Upgrade
 }
 
 enum BuildConfiguration {


### PR DESCRIPTION
Rewrite rdmd with `ProgramExecutionNoDebug`. Console is opened via run-script similar as in Geany, so it will not close immediately after execution. Tested on Ubuntu.  
TODO: terminal does not return `exit_code` back in application.