### PR TITLE
WIP: prefill the search panael text box with selected text from the editor

### DIFF
--- a/src/dlangide/ui/frame.d
+++ b/src/dlangide/ui/frame.d
@@ -986,6 +986,8 @@ class IDEFrame : AppFrame, ProgramExecutionStatusListener, BreakpointListChangeL
                     _logPanel.getTabs.selectTab("search");
                     if(searchPanel !is null) { 
                         searchPanel.focus();
+                        dstring selectedText = currentEditor.getSelectedText();
+                        searchPanel.setSearchText(selectedText);
                     }
                     return true;
                 case IDEActions.FileNewWorkspace:

--- a/src/dlangide/ui/searchPanel.d
+++ b/src/dlangide/ui/searchPanel.d
@@ -170,6 +170,10 @@ class SearchWidget : TabWidget {
         }
         return true;
     }
+    
+    public void setSearchText(dstring txt){
+        _findText.text = txt;
+    }
 
     protected bool onEditorAction(const Action action) {
         if (action.id == EditorActions.InsertNewLine) {


### PR DESCRIPTION
usecase: if DCD does not work or is not responsible i like to be able to select some text and then search for other occurrences.
If the ide automaticlly prefill the textbox for the search it much more comfortable.
It is standard behaivor in many (maybe every) popular applications (firefox, openoffice ...)
![prefill-search-text-box](https://cloud.githubusercontent.com/assets/10485658/13599939/19097ce6-e526-11e5-8725-f47c2fad572e.png)

WARNING NOT READY TO BE MERGED !!
======================================
because it depends on https://github.com/buggins/dlangui/pull/187
which must first be merged & released