### PR TITLE
close() disambiguation

### DIFF
--- a/src/dlangide/ui/terminal.d
+++ b/src/dlangide/ui/terminal.d
@@ -795,8 +795,8 @@ class TerminalDevice : Thread {
             }
         } else {
             if (masterfd && masterfd != -1) {
-                import core.sys.posix.unistd;
-                close(masterfd);
+                import core.sys.posix.unistd: close_=close;
+                close_(masterfd);
                 masterfd = 0;
             }
         }


### PR DESCRIPTION
The implicit close(masterfd) here actually calls dlangide.ui.terminal.TerminalDevice.close, which is not callable using argument types (int) and somehow leads to a compile failure instead of searching for the overload core.sys.posix.unistd.close. This fixes it anyway.