### PR TITLE
#409 - Fix for error(s) in build accessing std.ascii.isAlphaNum

### DIFF
--- a/src/dlangide/workspace/project.d
+++ b/src/dlangide/workspace/project.d
@@ -11,6 +11,7 @@ import std.file;
 import std.path;
 import std.process;
 import std.utf;
+import std.ascii;
 
 string[] includePath;
 
@@ -934,19 +935,19 @@ class DubPackageFinder {
 bool isValidProjectName(in string s) pure {
     if (s.empty)
         return false;
-    return reduce!q{ a && (b == '_' || b == '-' || std.ascii.isAlphaNum(b)) }(true, s);
+    return reduce!((a,b) => a && (b == '_' || b == '-' || std.ascii.isAlphaNum(b)))(true, s);
 }
 
 bool isValidModuleName(in string s) pure {
     if (s.empty)
         return false;
-    return reduce!q{ a && (b == '_' || std.ascii.isAlphaNum(b)) }(true, s);
+    return reduce!((a,b) => a && (b == '_' || std.ascii.isAlphaNum(b)))(true, s);
 }
 
 bool isValidFileName(in string s) pure {
     if (s.empty)
         return false;
-    return reduce!q{ a && (b == '_' || b == '.' || b == '-' || std.ascii.isAlphaNum(b)) }(true, s);
+    return reduce!((a,b) => a && (b == '_' || b == '.' || b == '-' || std.ascii.isAlphaNum(b)))(true, s);
 }
 
 unittest {


### PR DESCRIPTION
Fixes the issue seen on initial build:
```
Error: template instance `std.functional.F!(" a && (b == '_' || b == '.' || b == '-' || std.ascii.isAlphaNum(b)) ", "a", "b").binaryFun!(bool, dchar)` error instantiating
...
src\dlangide\workspace\project.d(949,90):        instantiated from here: reduce!(bool, string)
```

https://github.com/buggins/dlangide/issues/409