### PR TITLE
Update dlangui dependency to version 0.10.2

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -12,7 +12,7 @@
     "stringImportPaths": ["views"],
 
     "dependencies": {
-        "dlangui": "~>0.9.188",
+        "dlangui": "~>0.10.2",
         "dcd": "~>0.15.0-beta.1"
     },
 


### PR DESCRIPTION
This is to resolve issue #427 .
Before change: dub run would crash with and error of being unable to read module `sdl`. Updating the version required to 0.10.2 resolves this issue and the project can now build on a intel mac-book pro running Ventura 13.1.